### PR TITLE
Fix tag extraction logic for FictionsService

### DIFF
--- a/src/services/fictions.ts
+++ b/src/services/fictions.ts
@@ -280,7 +280,7 @@ class FictionsParser {
         const id = parseInt($(titleEl).attr('href')?.split('/')[2] ?? '', 10);
 
         const tags = $(el)
-            .find('span.label.bg-blue-dark')
+            .find('a.label.fiction-tag')
             .map((i, tag) => $(tag).text())
             .get();
 

--- a/test/fictions.spec.ts
+++ b/test/fictions.spec.ts
@@ -50,4 +50,14 @@ describe('fiction list functionality', () => {
         assert(fictions.success);
         assert(fictions.data.length === 0);
     });
+
+    it('should get fictions which contain tags', async () => {
+        // The tag extraction logic is in common "parseBlurb" logic, so the best / popular / latest
+        // APIs all exercise the same code path.
+        const fictions = await rr.fictions.getBest();
+
+        assert(fictions.success);
+        assert(fictions.data.length > 0);
+        fictions.data.map(fiction => fiction.tags).forEach(tags => assert(tags.length > 0));
+    });
 });


### PR DESCRIPTION
The library currently always returns an empty tag list even if tags are present on the fiction.

This is because the [tag extraction logic in `parseBlurb`](https://github.com/fs-c/royalroad-api/blob/8b81c706d70df1147fdeacb45cd2752e4abb0c16/src/services/fictions.ts#L282-L285) (which is used by all FictionsService methods) hasn't been updated to reflect Royalroad layout changes for these elements.

This change fixes this by updating the tag extraction path in parseBlurb which is used by all FictionsService methods.

It also adds a test to verify that tags are correctly extracted by a FictionsService method to ensure this doesn't silently fail in the future.